### PR TITLE
Prevent already defined NET_SSH2_LOGGING

### DIFF
--- a/core/class/Monitoring.class.php
+++ b/core/class/Monitoring.class.php
@@ -23,7 +23,9 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use phpseclib3\Net\SSH2;
 use phpseclib3\Crypt\PublicKeyLoader;
 
-define('NET_SSH2_LOGGING', 2);
+if (!defined('NET_SSH2_LOGGING')) {
+   define('NET_SSH2_LOGGING', 2);
+}
 
 class Monitoring extends eqLogic {
 


### PR DESCRIPTION
To prevent the PHP warning: NET_SSH2_LOGGING already defined in...