### PR TITLE
Correctif vue mobile - margin-right des widgets

### DIFF
--- a/core/template/mobile/Monitoring.html
+++ b/core/template/mobile/Monitoring.html
@@ -23,7 +23,7 @@
 			justify-content: flex-start;
 			align-items: center;
 		}
-		div.eqLogic-widget[data-eqLogic_uid="#uid#"] span.monitor-name-left i:not(:empty) {
+		div.eqLogic-widget[data-eqLogic_uid="#uid#"] span.monitor-name-left span:not(:empty) {
 			margin-right: 5px;
 		}
 		div.eqLogic-widget[data-eqLogic_uid="#uid#"] span.monitor-name-right {


### PR DESCRIPTION
Bonjour Titidom
J'ai détecté une petite coquille dans la vue mobile pour la margin que nous avions vu ensemble la dernière fois.
un "i" au lieu d'un span.
J'ai testé à mon niveau est c'est ok :
avant :
![image](https://github.com/user-attachments/assets/a043ba88-37a8-4edd-a882-2036873649ca)

après :
![image](https://github.com/user-attachments/assets/ff80ffc3-f2cb-456f-96bd-cdcc0daeab5c)
