### PR TITLE
v3.4.6

### DIFF
--- a/core/class/.htaccess
+++ b/core/class/.htaccess
@@ -1,2 +1,1 @@
-Order allow,deny
-Deny from all
+Require all denied

--- a/plugin_info/.htaccess
+++ b/plugin_info/.htaccess
@@ -1,5 +1,4 @@
-Order allow,deny
 <Files ~ "\.(jpg|jpeg|png|gif|pdf|txt|bmp)$">
-   allow from all
+    Require all granted
 </Files>
-Deny from all
+Require all denied

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "Monitoring",
 	"name": "Monitoring",
-	"pluginVersion": "3.4.5",
+	"pluginVersion": "3.4.6",
 	"description": {
 		"fr_FR": "Plugin pour surveiller vos systèmes Linux, NAS (Synology, QNAP, Medion), Proxmox, LXC et routeurs ASUS-WRT (locaux ou distants via SSH) : distribution, uptime, charge système, RAM, swap, disques, réseau, CPU, températures et commandes personnalisées.",
 		"en_US": "Plugin to monitor your Linux systems, NAS (Synology, QNAP, Medion), Proxmox, LXC and ASUS-WRT routers (local or remote via SSH): distribution, uptime, system load, RAM, swap, disks, network, CPU, temperatures and custom commands.",


### PR DESCRIPTION
This pull request updates access control directives in `.htaccess` files to use the modern Apache syntax and increments the plugin version in `info.json`. The changes improve security configuration and ensure compatibility with newer Apache versions.

**.htaccess security updates:**

* Updated `core/class/.htaccess` to use `Require all denied` instead of the deprecated `Order` and `Deny` directives for improved Apache 2.4+ compatibility.
* Updated `plugin_info/.htaccess` to replace `allow from all` and `Deny from all` with `Require all granted` and `Require all denied`, respectively, aligning with modern Apache syntax.

**Plugin metadata:**

* Bumped the `pluginVersion` from `3.4.5` to `3.4.6` in `plugin_info/info.json` to reflect these changes.