### PR TITLE
Remplacement de l'instruction event par checkAndUpdateCmd  

### DIFF
--- a/core/class/Monitoring.class.php
+++ b/core/class/Monitoring.class.php
@@ -4221,7 +4221,8 @@ class Monitoring extends eqLogic {
 					foreach ($dataresult as $key => $value) {
 						$cmd = $this->getCmd(null, $key);
 						if (is_object($cmd)) {
-							$cmd->event($value);
+							// $cmd->event($value);
+                    		$this->checkAndUpdateCmd($cmd, $value);
 						}
 					}
 
@@ -4241,7 +4242,8 @@ class Monitoring extends eqLogic {
 					foreach ($dataresult as $key => $value) {
 						$cmd = $this->getCmd(null, $key);
 						if (is_object($cmd)) {
-							$cmd->event($value);
+							// $cmd->event($value);
+                    		$this->checkAndUpdateCmd($cmd, $value);
 						}
 					}
 				}


### PR DESCRIPTION
… par checkAndUpdateCmd pour que les valeurs dupliquées soient ignorées

l'instruction event ne tient pas compte de l'option 'ne pas dupliquer les valeurs identiques' 

l'instruction checkAndUpdateCmd  applique le traitement standard et tient compte du paramétrage de l'historique de la commande