### PR TITLE
Bump actions/checkout to v7 in CI workflows

### DIFF
--- a/.github/workflows/checkPHP.yml
+++ b/.github/workflows/checkPHP.yml
@@ -13,7 +13,7 @@ jobs:
     name: PHP Lint — PHP 8.4
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       
       - name: PHP Syntax Checker (Lint)
         uses: StephaneBour/actions-php-lint@8.4

--- a/.github/workflows/checkPHPCompat.yml
+++ b/.github/workflows/checkPHPCompat.yml
@@ -18,7 +18,7 @@ jobs:
         php-version: ['7.4', '8.2', '8.4']
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/js-check.yml
+++ b/.github/workflows/js-check.yml
@@ -12,7 +12,7 @@ jobs:
   js-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
Updates three GitHub Actions workflows (`checkPHP.yml`, `checkPHPCompat.yml`, and `js-check.yml`) to use `actions/checkout@v7` instead of `@v6`, keeping CI dependencies current and consistent.